### PR TITLE
Change team results behaviour

### DIFF
--- a/DataManager/ModelMapperProfile.cs
+++ b/DataManager/ModelMapperProfile.cs
@@ -478,9 +478,11 @@ namespace iRLeagueManager
                 .ConstructUsing(source => new StandingsRowModel())
                 .ForMember(dest => dest.Member, opt => opt.MapFrom(src => GetLeagueMember(src.MemberId, modelCache)))
                 .ForMember(dest => dest.CountedResults, opt => opt.MapFrom(src => src.CountedResults.OrderBy(x => x.Date)))
-                .ForMember(dest => dest.Team, opt => opt.MapFrom(src => src.TeamId != null ? modelCache.PutOrGetModel(new TeamModel() { TeamId = src.TeamId.Value}) : null))
+                .ForMember(dest => dest.DroppedResults, opt => opt.MapFrom(src => src.DroppedResults.OrderBy(x => x.Date)))
+                .ForMember(dest => dest.Team, opt => opt.MapFrom(src => src.TeamId != null ? modelCache.PutOrGetModel(new TeamModel() { TeamId = src.TeamId.Value }) : null))
                 .EqualityComparison((src, dest) => src.MemberId == dest.Member.MemberId)
-                .Include<TeamStandingsRowDataDTO, TeamStandingsRowModel>();
+                .Include<TeamStandingsRowDataDTO, TeamStandingsRowModel>()
+                .AfterMap((src, dest) => dest.DroppedResults.ForEach(x => x.IsDroppedResult = true));
 
             CreateMap<TeamStandingsDataDTO, TeamStandingsModel>()
                 .ConstructUsing(source => modelCache.PutOrGetModel(new TeamStandingsModel() { ScoringTableId = source.ScoringTableId, SessionId = source.SessionId }))

--- a/DataManager/Models/Results/ResultRowModel.cs
+++ b/DataManager/Models/Results/ResultRowModel.cs
@@ -64,7 +64,10 @@ namespace iRLeagueManager.Models.Results
         public LeagueMember Member { get => member; set { member = value; OnPropertyChanged(); OnPropertyChanged(nameof(MemberId)); } }
         ILeagueMember IResultRow.Member => Member;
 
-        public string TeamName => Member?.Team?.Name;
+        private TeamModel team;
+        public TeamModel Team { get => team; set => SetValue(ref team, value); }
+
+        public string TeamName => Team?.Name;
 
         public long? MemberId { get => Member?.MemberId; }
 

--- a/DataManager/Models/Results/ScoredResultModel.cs
+++ b/DataManager/Models/Results/ScoredResultModel.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using System.Collections.ObjectModel;
 
 using iRLeagueManager.Attributes;
+using iRLeagueManager.Models.Members;
 
 namespace iRLeagueManager.Models.Results
 {
@@ -46,12 +47,20 @@ namespace iRLeagueManager.Models.Results
         private ObservableCollection<ScoredResultRowModel> finalResults;
         public ObservableCollection<ScoredResultRowModel> FinalResults { get => finalResults; set => SetNotifyCollection(ref finalResults, value); }
 
+        private ObservableCollection<LeagueMember> hardChargers;
+        public ObservableCollection<LeagueMember> HardChargers { get => hardChargers; set => SetNotifyCollection(ref hardChargers, value); }
+
+        private ObservableCollection<LeagueMember> cleanestDrivers;
+        public ObservableCollection<LeagueMember> CleanestDrivers { get => cleanestDrivers; set => SetNotifyCollection(ref cleanestDrivers, value); }
+
         public override long[] ModelId => new long[] { ResultId.GetValueOrDefault(), ScoringId.GetValueOrDefault() };
         //public override long[] ModelId => new long[] { ScoredResultId.GetValueOrDefault() };
 
         public  ScoredResultModel() : base()
         {
             FinalResults = new ObservableCollection<ScoredResultRowModel>();
+            CleanestDrivers = new ObservableCollection<LeagueMember>();
+            HardChargers = new ObservableCollection<LeagueMember>();
         }
 
         public static ScoredResultModel GetTemplate()

--- a/DataManager/Models/Results/ScoredResultRowModel.cs
+++ b/DataManager/Models/Results/ScoredResultRowModel.cs
@@ -66,6 +66,9 @@ namespace iRLeagueManager.Models.Results
 
         public override long[] ModelId => new long[] { ScoredResultRowId.GetValueOrDefault() };
 
+        private bool isDroppedResult;
+        public bool IsDroppedResult { get => isDroppedResult; set => SetValue(ref isDroppedResult, value); }
+
         public ScoredResultRowModel() : base() { }
 
         public new static ScoredResultRowModel GetTemplate()

--- a/DataManager/Models/Results/ScoringModel.cs
+++ b/DataManager/Models/Results/ScoringModel.cs
@@ -91,6 +91,13 @@ namespace iRLeagueManager.Models.Results
         private ObservableCollection<long> resultsFilterOptionIds;
         public ObservableCollection<long> ResultsFilterOptionIds { get => resultsFilterOptionIds; set => SetValue(ref resultsFilterOptionIds, value); }
 
+        private bool useResultSetTeam;
+        public bool UseResultSetTeam { get => useResultSetTeam; set => SetValue(ref useResultSetTeam, value); }
+
+        private bool updateTeamOnRecalculation;
+        public bool UpdateTeamOnRecalculation { get => updateTeamOnRecalculation; set => SetValue(ref updateTeamOnRecalculation, value); }
+
+
         private ScheduleInfo connectedschedule;
         public ScheduleInfo ConnectedSchedule
         {

--- a/DataManager/Models/Results/StandingsRowModel.cs
+++ b/DataManager/Models/Results/StandingsRowModel.cs
@@ -78,8 +78,8 @@ namespace iRLeagueManager.Models.Results
         private int racesCounted;
         public int RacesCounted { get => racesCounted; internal set => SetValue(ref racesCounted, value); }
 
-        private int droppedResults;
-        public int DroppedResults { get => droppedResults; internal set => SetValue(ref droppedResults, value); }
+        private int droppedResultCount;
+        public int DroppedResultCount { get => droppedResultCount; internal set => SetValue(ref droppedResultCount, value); }
 
         private int completedLaps;
         public int CompletedLaps { get => completedLaps; internal set => SetValue(ref completedLaps, value); }
@@ -130,7 +130,35 @@ namespace iRLeagueManager.Models.Results
         public int PositionChange { get => positionChange; internal set => SetValue(ref positionChange, value); }
 
         private IEnumerable<ScoredResultRowModel> countedResults;
-        public IEnumerable<ScoredResultRowModel> CountedResults { get => countedResults; set => SetValue(ref countedResults, value); }
+        public IEnumerable<ScoredResultRowModel> CountedResults 
+        { 
+            get => countedResults;
+            set
+            {
+                if (SetValue(ref countedResults, value))
+                {
+                    OnPropertyChanged(nameof(AllResults));
+                }
+            }
+        }
+
+        private IEnumerable<ScoredResultRowModel> droppedResults;
+        public IEnumerable<ScoredResultRowModel> DroppedResults
+        {
+            get => droppedResults;
+            set
+            {
+                if (SetValue(ref droppedResults, value))
+                {
+                    OnPropertyChanged(nameof(AllResults));
+                }
+            }
+        }
+
+        public IEnumerable<ScoredResultRowModel> AllResults => countedResults.Concat(droppedResults).OrderBy(x => x.Date);
+
+        private TeamModel team;
+        public TeamModel Team { get => team; set => SetValue(ref team, value); }
 
         public override long[] ModelId => Member.ModelId;
     }

--- a/DataManager/Models/SeasonModel.cs
+++ b/DataManager/Models/SeasonModel.cs
@@ -87,6 +87,9 @@ namespace iRLeagueManager.Models
         private bool hideCommentsBeforeVoted;
         public bool HideCommentsBeforeVoted { get => hideCommentsBeforeVoted; set => SetValue(ref hideCommentsBeforeVoted, value); }
 
+        private bool finished;
+        public bool Finished { get => finished; set => SetValue(ref finished, value); }
+
         // client.Results.Where(x => Sessions.Select(y => y.SessionId).Contains(x.SessionId));
 
         //public IEnumerable<ISession> Sessions => Schedules.Select(x => x.Sessions.AsEnumerable()).Aggregate((x, y) => x.Concat(y));

--- a/ResultsParser/CSVParser.cs
+++ b/ResultsParser/CSVParser.cs
@@ -154,6 +154,7 @@ namespace iRLeagueManager.ResultsParser
                 if (MemberList.Any(x => x.IRacingId == line["CustID"]))
                 {
                     row.Member = MemberList.SingleOrDefault(x => x.IRacingId == line["CustID"]);
+                    row.Team = row.Member.Team;
                 }
                 //row.Interval = new LapInterval(
                 //    TimeSpan.TryParse("0:" + line["Interval"].Replace("-",""), culture, out TimeSpan intvTime) ? intvTime : TimeSpan.Zero,

--- a/ResultsParser/JsonParser.cs
+++ b/ResultsParser/JsonParser.cs
@@ -108,6 +108,7 @@ namespace iRLeagueManager.ResultsParser
                 if (MemberList.Any(x => x.IRacingId == (string)resultRow.cust_id))
                 {
                     row.Member = MemberList.SingleOrDefault(x => x.IRacingId == (string)resultRow.cust_id);
+                    row.Team = row.Member.Team;
                 }
                 //row.Interval = new LapInterval(
                 //    TimeSpan.TryParse("0:" + line["Interval"].Replace("-",""), culture, out TimeSpan intvTime) ? intvTime : TimeSpan.Zero,

--- a/iRLeagueManager/Exceptions/ModelSourceNullException.cs
+++ b/iRLeagueManager/Exceptions/ModelSourceNullException.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace iRLeagueManager.Exceptions
+{
+    public class ModelSourceNullException : Exception
+    {
+        public Type SourceType { get; }
+        public Type ContainerType { get; }
+        public object PreviousModel { get; }
+
+        public ModelSourceNullException(Type sourceType, Type containerType, object previousModel = null) : this(
+                $"Error while updating model source: source was null\n" +
+                $"\tSource type:\t{sourceType}\n" +
+                $"\tContainer type:\t{containerType}\n", sourceType, containerType, previousModel)
+        {
+        }
+
+        public ModelSourceNullException(string message, Type sourceType, Type containerType, object previousModel = null) : this(message, sourceType, containerType, null, previousModel)
+        {
+        }
+
+        public ModelSourceNullException(string message, Type sourceType, Type containerType, Exception innerException, object previousModel = null) : base(message, innerException)
+        {
+            SourceType = sourceType;
+            ContainerType = containerType;
+            PreviousModel = previousModel;
+        }
+    }
+}

--- a/iRLeagueManager/ViewModels/ContainerModelBase.cs
+++ b/iRLeagueManager/ViewModels/ContainerModelBase.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.ComponentModel;
+using iRLeagueManager.Exceptions;
 
 namespace iRLeagueManager.ViewModels
 {
@@ -73,7 +74,8 @@ namespace iRLeagueManager.ViewModels
         {
             if (source == null)
             {
-                throw new ArgumentNullException(nameof(source));
+                //throw new ArgumentNullException(nameof(source));
+                throw new ModelSourceNullException(typeof(TSource), this.GetType(), _source);
             }
 
             bool hasChanged;

--- a/iRLeagueManager/ViewModels/LeagueContainerModel.cs
+++ b/iRLeagueManager/ViewModels/LeagueContainerModel.cs
@@ -31,6 +31,7 @@ using iRLeagueManager.Models;
 using iRLeagueManager.Data;
 using iRLeagueManager;
 using System.Windows;
+using System.CodeDom;
 
 namespace iRLeagueManager.ViewModels
 {

--- a/iRLeagueManager/ViewModels/ResultRowViewModel.cs
+++ b/iRLeagueManager/ViewModels/ResultRowViewModel.cs
@@ -68,6 +68,7 @@ namespace iRLeagueManager.ViewModels
         public LapTime AvgLapTime { get => Source.AvgLapTime; set => Source.AvgLapTime = value; }
         public LapTime FastestLapTime { get => Source.FastestLapTime; set => Source.FastestLapTime = value; }
         public int PositionChange { get => Source.PositionChange; }
+        public TeamModel Team { get => Model.Team; set => Model.Team = value; }
 
         public int OldIRating => Model.OldIRating;
         public int NewIRating => Model.NewIRating;

--- a/iRLeagueManager/ViewModels/ScoringViewModel.cs
+++ b/iRLeagueManager/ViewModels/ScoringViewModel.cs
@@ -62,6 +62,9 @@ namespace iRLeagueManager.ViewModels
         public ScoringInfo ExtScoringSource { get => Model.ExtScoringSource; set => Model.ExtScoringSource = value; }
         public bool TakeResultsFromExtSource { get => Model.TakeResultsFromExtSource; set => Model.TakeResultsFromExtSource = value; }
         public ObservableCollection<long> ResultsFilterOptionIds => Model.ResultsFilterOptionIds;
+        public bool UseResultSetTeam { get => Model.UseResultSetTeam; set => Model.UseResultSetTeam = value; }
+        public bool UpdateTeamOnRecalculation { get => Model.UpdateTeamOnRecalculation; set => Model.UpdateTeamOnRecalculation = value; }
+
 
         private CollectionViewSource scoringListSource;
         public ICollectionView ScoringList

--- a/iRLeagueManager/ViewModels/SeasonViewModel.cs
+++ b/iRLeagueManager/ViewModels/SeasonViewModel.cs
@@ -73,6 +73,8 @@ namespace iRLeagueManager.ViewModels
 
         public bool HideCommentsBeforeVoted { get => Model.HideCommentsBeforeVoted; set => Model.HideCommentsBeforeVoted = value; }
 
+        public bool Finished { get => Model.Finished; set => Model.Finished = value; }
+
         public SeasonViewModel() : base()
         {
             SeasonModel.GetTemplate();

--- a/iRLeagueManager/Views/ScoredResultControl.xaml
+++ b/iRLeagueManager/Views/ScoredResultControl.xaml
@@ -302,31 +302,6 @@ SOFTWARE.-->
                                                     </Style>
                                                 </DataGridTextColumn.ElementStyle>
                                             </DataGridTextColumn>
-                                            <!--<DataGridTextColumn Header="Chg." Binding="{Binding PositionChange, StringFormat={}{0:+#;-#;' - '}}" 
-                                                                IsReadOnly="True" Width="45" MinWidth="45">
-                                                <DataGridTextColumn.ElementStyle>
-                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
-                                                        <Setter Property="TextAlignment" Value="Center"/>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding PositionChange, 
-                                                                         Converter={StaticResource CompareNumericalConverter}, ConverterParameter=0}" Value="1">
-                                                                <Setter Property="Foreground" Value="Green"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding PositionChange, 
-                                                                         Converter={StaticResource CompareNumericalConverter}, ConverterParameter=0}" Value="-1">
-                                                                <Setter Property="Foreground" Value="Red"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </DataGridTextColumn.ElementStyle>
-                                            </DataGridTextColumn>
-                                            <DataGridTextColumn Header="Start" Binding="{Binding StartPosition, StringFormat={}{0}.}" IsReadOnly="True" Width="50" MinWidth="50">
-                                                <DataGridTextColumn.ElementStyle>
-                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
-                                                        <Setter Property="TextAlignment" Value="Center"/>
-                                                    </Style>
-                                                </DataGridTextColumn.ElementStyle>
-                                            </DataGridTextColumn>-->
                                             <DataGridTextColumn Header="Name" Binding="{Binding Member.FullName}" IsReadOnly="True" Width="*" MinWidth="150"
                                                                 ElementStyle="{StaticResource TextColumnElementStyle}" MaxWidth="550"/>
                                             <DataGridTextColumn Header="Fast Lap" IsReadOnly="True" Width="100" MinWidth="90">
@@ -513,21 +488,6 @@ SOFTWARE.-->
                                                     </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>
                                             </DataGridTemplateColumn>
-                                            <!--<DataGridTemplateColumn Width="30" MinWidth="30">
-                                                <DataGridTemplateColumn.CellTemplate>
-                                                    <DataTemplate>
-                                                        <controls:IconButton Click="DeleteRowButton_Click" Tag="{Binding}"
-                                                                             Width="28" Height="25" Margin="-5,0,0,0" Padding="2"
-                                                                             IconFill="{StaticResource ThemeColor_Back5}">
-                                                            <controls:IconButton.IconContent>
-                                                                <Viewbox>
-                                                                    <ContentControl Content="{StaticResource delete}"/>
-                                                                </Viewbox>
-                                                            </controls:IconButton.IconContent>
-                                                        </controls:IconButton>
-                                                    </DataTemplate>
-                                                </DataGridTemplateColumn.CellTemplate>
-                                            </DataGridTemplateColumn>-->
                                         </DataGrid.Columns>
                                     </DataGrid>
                                     <DataTemplate.Triggers>
@@ -550,7 +510,8 @@ SOFTWARE.-->
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
                                 <DataGridTemplateColumn Header="Team" IsReadOnly="True" Width="15*"
-                                                        MaxWidth="550" MinWidth="150" x:Name="TeamTeamNameColumn">
+                                                        MaxWidth="550" MinWidth="150" x:Name="TeamTeamNameColumn"
+                                                        SortMemberPath="Team.Name">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">
@@ -582,7 +543,8 @@ SOFTWARE.-->
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTextColumn Header="Fast Lap" IsReadOnly="True" Width="100" MinWidth="90" x:Name="TeamFastLapColumn">
+                                <DataGridTextColumn Header="Fast Lap" IsReadOnly="True" Width="100" MinWidth="90" x:Name="TeamFastLapColumn"
+                                                    SortMemberPath="FastestLapTime">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -596,7 +558,8 @@ SOFTWARE.-->
                                         </MultiBinding>
                                     </DataGridTextColumn.Binding>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="Avg. Lap" IsReadOnly="True" Width="100" MinWidth="90">
+                                <DataGridTextColumn Header="Avg. Lap" IsReadOnly="True" Width="100" MinWidth="90"
+                                                    SortMemberPath="AvgLapTime">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -610,7 +573,8 @@ SOFTWARE.-->
                                         </MultiBinding>
                                     </DataGridTextColumn.Binding>
                                 </DataGridTextColumn>
-                                <DataGridTemplateColumn Header="Interval" IsReadOnly="True" Width="100" MinWidth="90">
+                                <DataGridTemplateColumn Header="Interval" IsReadOnly="True" Width="100" MinWidth="90"
+                                                        SortMemberPath="Interval">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="---" HorizontalAlignment="Center"/>
@@ -627,7 +591,8 @@ SOFTWARE.-->
                                         <TextBlock Text="Race Pts." TextWrapping="Wrap"/>
                                     </DataGridTextColumn.Header>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding BonusPoints, StringFormat={}{0:+#;-#;-}}" IsReadOnly="True" Width="90" MinWidth="58">
+                                <DataGridTextColumn Binding="{Binding BonusPoints, StringFormat={}{0:+#;-#;-}}" IsReadOnly="True" Width="90" MinWidth="58"
+                                                    SortMemberPath="BonusPoints">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -638,7 +603,7 @@ SOFTWARE.-->
                                     </DataGridTextColumn.Header>
                                 </DataGridTextColumn>
                                 <DataGridTextColumn Binding="{Binding PenaltyPoints, StringFormat={}{0:-#;+#;-}}" IsReadOnly="True" 
-                                                    Width="90" MinWidth="50">
+                                                    Width="90" MinWidth="50" SortMemberPath="PenaltyPoints">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -736,19 +701,19 @@ SOFTWARE.-->
                                     <Setter Property="TextBlock.TextAlignment" Value="Center"/>
                                     <Setter Property="HorizontalContentAlignment" Value="Center"/>
                                     <!--<Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
-                            <Border Padding="{TemplateBinding Padding}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
-                                <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center"/>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>-->
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
+                                                <Border Padding="{TemplateBinding Padding}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                                                    <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center"/>
+                                                </Border>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>-->
                                 </Style>
                             </DataGrid.ColumnHeaderStyle>
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="Pos." Binding="{Binding FinalPosition, StringFormat={}{0}.}" IsReadOnly="True" Width="45" 
-                                                    MinWidth="45" TextElement.FontWeight="Bold">
+                                                    MinWidth="45" TextElement.FontWeight="Bold" SortMemberPath="FinalPosition" SortDirection="Ascending">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -756,7 +721,7 @@ SOFTWARE.-->
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
                                 <DataGridTextColumn Header="Chg." Binding="{Binding PositionChange, StringFormat={}{0:+#;-#;' - '}}" 
-                                                                IsReadOnly="True" Width="45" MinWidth="45">
+                                                                IsReadOnly="True" Width="45" MinWidth="45" SortMemberPath="PositionChange">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -773,16 +738,68 @@ SOFTWARE.-->
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="Start" Binding="{Binding StartPosition, StringFormat={}{0}.}" IsReadOnly="True" Width="50" MinWidth="50">
+                                <DataGridTextColumn Header="Start" Binding="{Binding StartPosition, StringFormat={}{0}.}" IsReadOnly="True" Width="50" MinWidth="50"
+                                                    SortMemberPath="StartPosition">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="Name" Binding="{Binding Member.FullName}" IsReadOnly="True" Width="*" MinWidth="150"
-                                                    ElementStyle="{StaticResource TextColumnElementStyle}" FontWeight="Bold">
-                                    <DataGridTextColumn.CellStyle>
+                                <DataGridTemplateColumn Header="Name" IsReadOnly="True" Width="*" MinWidth="150"
+                                                    SortMemberPath="Member.FullName">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                                <TextBlock Text="{Binding Member.FullName}" FontWeight="Bold" />
+                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
+                                                    <Border CornerRadius="8" BorderThickness="1" BorderBrush="DarkGray" Width="16" Height="16" 
+                                                            Background="LightGoldenrodYellow">
+                                                        <TextBlock Text="H" ToolTip="Hard Charger" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding HardCharger}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
+                                                    </Border>
+                                                    <Border CornerRadius="8" BorderThickness="1" BorderBrush="DarkGray" Width="16" Height="16"
+                                                            Background="PaleGreen">
+                                                        <TextBlock Text="C" ToolTip="Cleanest Driver" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding CleanestDriver}" Value="True">
+                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding CleanestDriver}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
+                                                    </Border>
+                                                    <StackPanel.RenderTransform>
+                                                        <TranslateTransform X="4" Y="-4"/>
+                                                    </StackPanel.RenderTransform>
+                                                </StackPanel>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                    <DataGridTemplateColumn.CellStyle>
                                         <Style TargetType="DataGridCell" BasedOn="{StaticResource ResultsGridCellStyle}">
                                             <Setter Property="ToolTip">
                                                 <Setter.Value>
@@ -797,37 +814,60 @@ SOFTWARE.-->
                                                                 <RowDefinition Height="Auto"/>
                                                                 <RowDefinition Height="Auto"/>
                                                                 <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
                                                             </Grid.RowDefinitions>
                                                             <TextBlock Text="iRacing id: " Grid.Row="0" Grid.Column="0"/>
                                                             <TextBlock Text="{Binding Member.IRacingId, FallbackValue=''}" Grid.Row="0" Grid.Column="1"/>
 
                                                             <TextBlock Text="iRating Start: " Grid.Row="1" Grid.Column="0"/>
                                                             <TextBlock Text="{Binding OldIRating, FallbackValue=0}" Grid.Row="1" Grid.Column="1"/>
-                                                            
+
                                                             <TextBlock Text="iRating End: " Grid.Row="2" Grid.Column="0"/>
                                                             <TextBlock Text="{Binding NewIRating, FallbackValue=0}" Grid.Row="2" Grid.Column="1"/>
 
                                                             <TextBlock Text="Safety Rating: " Grid.Row="3" Grid.Column="0"/>
                                                             <TextBlock Text="{Binding NewSafetyRating, FallbackValue=0}" Grid.Row="3" Grid.Column="1"/>
+
+                                                            <TextBlock Text="Hard Charger: " Grid.Row="4" Grid.Column="0"/>
+                                                            <TextBlock Text="{Binding HardCharger}" Grid.Row="4" Grid.Column="1"/>
+
+                                                            <TextBlock Text="Cleanest Driver: " Grid.Row="5" Grid.Column="0"/>
+                                                            <TextBlock Text="{Binding CleanestDriver}" Grid.Row="5" Grid.Column="1"/>
                                                         </Grid>
                                                     </ToolTip>
                                                 </Setter.Value>
                                             </Setter>
                                         </Style>
-                                    </DataGridTextColumn.CellStyle>
-                                </DataGridTextColumn>
+                                    </DataGridTemplateColumn.CellStyle>
+                                </DataGridTemplateColumn>
                                 <!--<DataGridTextColumn Header="Team" Binding="{Binding Member.Team.TeamColor}" IsReadOnly="True" Width="*" MinWidth="150"
                                                                 ElementStyle="{StaticResource TextColumnElementStyle}" Foreground="{Binding Member.Team.TeamColor}"/>-->
                                 <DataGridTemplateColumn Header="Team" IsReadOnly="True" Width="15*"
-                                                        MaxWidth="450" MinWidth="150">
+                                                        MaxWidth="450" MinWidth="150"
+                                                        SortMemberPath="Member.Team.Name">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock Text="{Binding Member.Team.Name}" Foreground="{Binding Member.Team.TeamColor}" 
+                                            <TextBlock Text="{Binding Team.Name}" Foreground="{Binding Team.TeamColor}" 
                                                        FontWeight="DemiBold"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTextColumn Header="Fast Lap" IsReadOnly="True" Width="80" MinWidth="80">
+                                <DataGridTextColumn Header="Qualy Lap" IsReadOnly="True" Width="80" MinWidth="80" SortMemberPath="QualifyingTime">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
+                                            <Setter Property="TextAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                    <DataGridTextColumn.Binding>
+                                        <MultiBinding StringFormat="{}{0:00}:{1:00},{2:000}">
+                                            <Binding Path="QualifyingTime.Minutes"/>
+                                            <Binding Path="QualifyingTime.Seconds"/>
+                                            <Binding Path="QualifyingTime.Milliseconds"/>
+                                        </MultiBinding>
+                                    </DataGridTextColumn.Binding>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Header="Fast Lap" IsReadOnly="True" Width="80" MinWidth="80" SortMemberPath="FastestLapTime">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -841,7 +881,7 @@ SOFTWARE.-->
                                         </MultiBinding>
                                     </DataGridTextColumn.Binding>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="Avg. Lap" IsReadOnly="True" Width="80" MinWidth="80">
+                                <DataGridTextColumn Header="Avg. Lap" IsReadOnly="True" Width="80" MinWidth="80" SortMemberPath="AvgLapTime">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -856,7 +896,7 @@ SOFTWARE.-->
                                     </DataGridTextColumn.Binding>
                                 </DataGridTextColumn>
                                 <DataGridTextColumn Header="Interval" Binding="{Binding Interval, Converter={StaticResource LapIntervalStringConverter}}" 
-                                                    Width="80" MinWidth="80">
+                                                    Width="80" MinWidth="80" SortMemberPath="Interval">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
                                             <Setter Property="TextAlignment" Value="Center"/>
@@ -903,7 +943,7 @@ SOFTWARE.-->
                                         <TextBlock Text="Bonus Pts." TextWrapping="Wrap"/>
                                     </DataGridTextColumn.Header>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn IsReadOnly="True" Width="50" MinWidth="50">
+                                <DataGridTextColumn IsReadOnly="True" Width="50" MinWidth="50" SortMemberPath="PenaltyPoints">
                                     <DataGridTextColumn.Binding>
                                         <MultiBinding StringFormat="{}{0:-#;#;-} {1:[#];[#];''}">
                                             <Binding Path="PenaltyPoints"/>
@@ -975,6 +1015,14 @@ SOFTWARE.-->
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding Incidents}" IsReadOnly="True" Width="50" MinWidth="50"
+                                                    Header="Incs.">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
+                                            <Setter Property="TextAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
                                 <DataGridTextColumn Binding="{Binding TotalPoints}" IsReadOnly="True" Width="50" MinWidth="50">
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">
@@ -985,13 +1033,13 @@ SOFTWARE.-->
                                         <TextBlock Text="Total Pts." TextWrapping="Wrap"/>
                                     </DataGridTextColumn.Header>
                                 </DataGridTextColumn>
-                                <DataGridTemplateColumn Header="Add Penalty" Width="105" MinWidth="105" Visibility="Collapsed">
+                                <DataGridTemplateColumn Header="Add Penalty" Width="105" MinWidth="105" Visibility="Visible">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">
                                                 <ComboBox SelectedValue="{Binding AddPenalty.PenaltyPoints, UpdateSourceTrigger=PropertyChanged}" 
                                                           DisplayMemberPath="" SelectedValuePath="Content" Width="40" VerticalContentAlignment="Center"
-                                                          Margin="0" Height="25">
+                                                          Margin="0" Height="25" IsEditable="True">
                                                     <ComboBox.Style>
                                                         <Style TargetType="ComboBox">
                                                             <Setter Property="IsReadOnly" Value="True"/>

--- a/iRLeagueManager/Views/SettingsControl.xaml
+++ b/iRLeagueManager/Views/SettingsControl.xaml
@@ -75,6 +75,7 @@ SOFTWARE.-->
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Season Id:" Margin="5"/>
@@ -83,6 +84,9 @@ SOFTWARE.-->
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Season Name:" Margin="5"/>
                             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SeasonName}" Margin="5"/>
 
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Finished:" Margin="5"/>
+                            <CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding Finished}" Margin="5"
+                                      VerticalAlignment="Center"/>
                         </Grid>
                     </controls:HeaderedBorder>
                 </TabItem>
@@ -91,7 +95,6 @@ SOFTWARE.-->
                         <TextBlock Text="Results" FontSize="{StaticResource Global.FontSizeLarge}" FontWeight="Bold" Margin="4,8"/>
                     </TabItem.Header>
                     <DockPanel Grid.Row="1" Margin="0" VerticalAlignment="Stretch">
-                        <!--<TextBlock Text="Scorings" FontSize="18" FontWeight="Bold" Margin="5" DockPanel.Dock="Top"/>-->
                         <controls:HeaderedBorder DockPanel.Dock="Left" BorderBrush="DarkGray" BorderThickness="1" Margin="10" Padding="5"
                                                  Header="Scorings">
                             <Grid>
@@ -186,7 +189,7 @@ SOFTWARE.-->
                                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Member or Team Scoring:" Margin="5"/>
                                         <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding Source={StaticResource ScoringKindValues}}" SelectedItem="{Binding ScoringKind}" Margin="5"/>
 
-                                        <CheckBox Grid.Row="4" Grid.Column="1" IsChecked="{Binding TakeResultsFromExtSource}" Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="4" Grid.Column="1" IsChecked="{Binding TakeResultsFromExtSource}" Margin="5" VerticalAlignment="Center"/>
                                         <TextBlock Grid.Row="4" Grid.Column="0" Text="Take Results from other Scoring" Margin="5" TextWrapping="WrapWithOverflow"/>
 
                                         <Grid Grid.Row="5" Grid.ColumnSpan="2" Margin="10,0,0,0">
@@ -211,6 +214,12 @@ SOFTWARE.-->
                                                 </Style>
                                             </Grid.Style>
                                         </Grid>
+
+                                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Get Teams from raw Result" Margin="5" TextWrapping="WrapWithOverflow"/>
+                                        <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding UseResultSetTeam}" VerticalAlignment="Center" Margin="5"/>
+
+                                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Update Teams on recalculation" Margin="5" TextWrapping="WrapWithOverflow"/>
+                                        <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding UpdateTeamOnRecalculation}" VerticalAlignment="Center" Margin="5"/>
                                     </Grid>
                                 </controls:HeaderedBorder>
                                 <controls:HeaderedBorder Margin="5,10" Header="Results Calculation">

--- a/iRLeagueManager/Views/StandingsControl.xaml
+++ b/iRLeagueManager/Views/StandingsControl.xaml
@@ -281,7 +281,7 @@ SOFTWARE.-->
                                                         MaxWidth="300" MinWidth="100">
                                                 <DataGridTemplateColumn.CellTemplate>
                                                     <DataTemplate>
-                                                        <TextBlock Text="{Binding Member.Team.Name}" Foreground="{Binding Member.Team.TeamColor}" 
+                                                        <TextBlock Text="{Binding Team.Name}" Foreground="{Binding Team.TeamColor}" 
                                                        FontWeight="DemiBold" VerticalAlignment="Center" Margin="5,0"/>
                                                     </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>

--- a/iRLeagueManager/Views/StandingsControl.xaml
+++ b/iRLeagueManager/Views/StandingsControl.xaml
@@ -691,8 +691,8 @@ SOFTWARE.-->
                                     </DataGrid>
                                 </DataTemplate>
                                 <DataTemplate x:Key="StandingsRowModelDataGrid">
-                                    <DataGrid ItemsSource="{Binding CountedResults}" AutoGenerateColumns="False" VerticalAlignment="Stretch"
-                                              BorderBrush="Black" RowBackground="#F0FFFF" IsReadOnly="True"
+                                    <DataGrid ItemsSource="{Binding AllResults}" AutoGenerateColumns="False" VerticalAlignment="Stretch"
+                                              BorderBrush="Black" IsReadOnly="True"
                                               PreviewMouseWheel="DataGrid_PreviewMouseWheel"
                                               TextElement.FontSize="{StaticResource Global.FontSizeSmall}" 
                                               CanUserAddRows="False" CanUserDeleteRows="False"
@@ -706,6 +706,17 @@ SOFTWARE.-->
                                         <DataGrid.RowHeaderStyle>
                                             <Style TargetType="DataGridRowHeader" BasedOn="{StaticResource DataGridRowHeaderStyle}"/>
                                         </DataGrid.RowHeaderStyle>
+                                        <DataGrid.RowStyle>
+                                            <Style TargetType="DataGridRow">
+                                                <Setter Property="Background" Value="#F0FFFF"/>
+                                                <Setter Property="TextBlock.TextDecorations" Value="Strikethrough"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsDroppedResult}" Value="True">
+                                                        <Setter Property="Background" Value="#E0E9E9"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DataGrid.RowStyle>
                                         <DataGrid.ColumnHeaderStyle>
                                             <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource DataGridColumnHeaderStyle}"/>
                                         </DataGrid.ColumnHeaderStyle>
@@ -730,6 +741,7 @@ SOFTWARE.-->
                                                     </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>
                                             </DataGridTemplateColumn>-->
+                                            <DataGridTextColumn Header="Drop" Binding="{Binding IsDroppedResult}" IsReadOnly="True" Width="50" MinWidth="50"/>
                                             <DataGridTextColumn Header="Fast Lap" IsReadOnly="True" Width="100" MinWidth="80">
                                                 <DataGridTextColumn.ElementStyle>
                                                     <Style TargetType="TextBlock" BasedOn="{StaticResource TextColumnElementStyle}">

--- a/iRLeagueManager/Views/StatsPageControl.xaml
+++ b/iRLeagueManager/Views/StatsPageControl.xaml
@@ -94,8 +94,9 @@ SOFTWARE.-->
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>
                 <DataTemplate>
-                    <Grid DataContext="{Binding DriverStatistic}" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled">
-                        <DataGrid ItemsSource="{Binding DriverStatisticRows}">
+                    <Grid DataContext="{Binding DriverStatistic}" ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                          ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                        <DataGrid ItemsSource="{Binding DriverStatisticRows}" AutoGenerateColumns="False">
                             <DataGrid.CellStyle>
                                 <Style TargetType="DataGridCell" BasedOn="{StaticResource ResultsGridCellStyle}"/>
                             </DataGrid.CellStyle>
@@ -105,6 +106,41 @@ SOFTWARE.-->
                             <DataGrid.ColumnHeaderStyle>
                                 <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource DataGridColumnHeaderStyle}"/>
                             </DataGrid.ColumnHeaderStyle>
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Driver" Binding="{Binding LeagueMember.FullName}"/>
+                                <DataGridTextColumn Header="Team" Binding="{Binding LeagueMember.Team.Name}"/>
+                                <DataGridTextColumn Header="IRating" Binding="{Binding EndIRating}"/>
+                                <DataGridTextColumn Header="SR" Binding="{Binding EndSRating}"/>
+                                <DataGridTextColumn Header="First Race" Binding="{Binding FirstRaceDate}"/>
+                                <DataGridTextColumn Header="Last Race" Binding="{Binding LastRaceDate}"/>
+                                <DataGridTextColumn Header="Last Pos." Binding="{Binding LastRaceFinalPosition}"/>
+                                <DataGridTextColumn Header="Avg. Pos" Binding="{Binding AvgFinalPosition, StringFormat={} {0:0.00}}"/>
+                                <DataGridTextColumn Header="Poles" Binding="{Binding Poles}"/>
+                                <DataGridTextColumn Header="Races" Binding="{Binding Races}"/>
+                                <DataGridTextColumn Header="Finished" Binding="{Binding RacesCompleted}"/>
+                                <DataGridTextColumn Header="Finished Pct." Binding="{Binding RacesCompletedPct, StringFormat={} {0:0.00}}"/>
+                                <DataGridTextColumn Header="Titles" Binding="{Binding Titles}"/>
+                                <DataGridTextColumn Header="Driven km" Binding="{Binding DrivenKm, StringFormat={} {0:0.0}}"/>
+                                <DataGridTextColumn Header="Leading km" Binding="{Binding LeadingKm}"/>
+                                <DataGridTextColumn Header="Incs" Binding="{Binding Incidents}"/>
+                                <DataGridTextColumn Header="Race Pts." Binding="{Binding RacePoints}"/>
+                                <DataGridTextColumn Header="Bonus Pts." Binding="{Binding BonusPoints}"/>
+                                <DataGridTextColumn Header="Total Pts." Binding="{Binding TotalPoints}"/>
+                                <DataGridTextColumn Header="Penalty Pts." Binding="{Binding PenaltyPoints}"/>
+                                <DataGridTextColumn Header="Pts. per Race" Binding="{Binding AvgPointsPerRace, StringFormat={} {0:0.00}}"/>
+                                <DataGridTextColumn Header="Best Qualy" Binding="{Binding BestStartPosition}"/>
+                                <DataGridTextColumn Header="Best Race" Binding="{Binding BestFinalPosition}"/>
+                                <DataGridTextColumn Header="Wins" Binding="{Binding Wins}"/>
+                                <DataGridTextColumn Header="Top3" Binding="{Binding Top3}"/>
+                                <DataGridTextColumn Header="Top5" Binding="{Binding Top5}"/>
+                                <DataGridTextColumn Header="Top10" Binding="{Binding Top10}"/>
+                                <DataGridTextColumn Header="Top15" Binding="{Binding Top15}"/>
+                                <DataGridTextColumn Header="Top20" Binding="{Binding Top20}"/>
+                                <DataGridTextColumn Header="CleanestDriver" Binding="{Binding CleanestDriverAwards}"/>
+                                <DataGridTextColumn Header="HardCharger" Binding="{Binding HardChargerAwards}"/>
+                                <DataGridTextColumn Header="FastestLaps" Binding="{Binding FastestLaps}"/>
+                                <DataGridTextColumn Header="Season Pos." Binding="{Binding CurrentSeasonPosition}"/>
+                            </DataGrid.Columns>
                         </DataGrid>
                     </Grid>
                 </DataTemplate>

--- a/iRLeagueManager/iRLeagueManager.csproj
+++ b/iRLeagueManager/iRLeagueManager.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Converters\ToUpperConverter.cs" />
     <Compile Include="Converters\UniversalColorConverter.cs" />
     <Compile Include="Converters\VisibilityConverter.cs" />
+    <Compile Include="Exceptions\ModelSourceNullException.cs" />
     <Compile Include="Extensions\ItemsControlExtensions.cs" />
     <Compile Include="Extensions\ModalExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />


### PR DESCRIPTION
Add Team info to ResultRow and ScoredResultRow
Show Team info from ResultRow instead of Member
- This prevents the Team changing in past seasons if the Member choses another Team